### PR TITLE
Git integration check-ignore command

### DIFF
--- a/plugins/git4idea/src/git4idea/commands/GitCommand.java
+++ b/plugins/git4idea/src/git4idea/commands/GitCommand.java
@@ -39,6 +39,7 @@ public class GitCommand {
   public static final GitCommand BRANCH = read("branch");
   public static final GitCommand CHECKOUT = write("checkout");
   public static final GitCommand CHECK_ATTR = read("check-attr");
+  public static final GitCommand CHECK_IGNORE = read("check-ignore");
   public static final GitCommand COMMIT = write("commit");
   public static final GitCommand CONFIG = read("config");
   public static final GitCommand CHERRY = read("cherry");


### PR DESCRIPTION
Added `check-ignore` command for git integration to allow check if separate pathname/filename under `.gitignore`. To see specification for command click on link [check-ignore](https://git-scm.com/docs/git-check-ignore)